### PR TITLE
Remove British Broadcasting Company domains from torrent.txt

### DIFF
--- a/torrent.txt
+++ b/torrent.txt
@@ -74,8 +74,6 @@
 0.0.0.0 azn-project.depthstrike.com
 0.0.0.0 aznanime.tk
 0.0.0.0 bakuretsu-extend.org
-0.0.0.0 bbc.co.uk
-0.0.0.0 bbcworld.com
 0.0.0.0 bblc.tv
 0.0.0.0 bean-crisis.org
 0.0.0.0 benfrank.net


### PR DESCRIPTION


## Summary

removed following news & entertainment entries from the Torrent sites list:

0.0.0.0 bbc.co.uk
0.0.0.0 bbcworld.com

https://www.whois.com/whois/bbc.co.uk
https://www.whois.com/whois/bbcworld.com

https://en.wikipedia.org/wiki/BBC

## Checklist

- [ ✓ ] I have verified that I have not modified any files inside the `alt-version` folder (automated code will automatically update those files)

- [ ✓ ] I have verified that I have not modified any files inside the `dnsmasq-version` folder (automated code will automatically update those files)
